### PR TITLE
Remove call to `docker kill`

### DIFF
--- a/commands
+++ b/commands
@@ -76,9 +76,6 @@ case "$1" in
       docker exec -it "$ID" chmod -R 777 /data
 
       service_stop "$SERVICE"
-      dokku_log_verbose_quiet "Killing container"
-      docker kill "$ID" > /dev/null || true
-      sleep 1
 
       dokku_log_verbose_quiet "Removing container"
       docker rm -v "$ID" > /dev/null


### PR DESCRIPTION
Call to `docker kill` is useless since `docker stop` already kills the running container after a grace period (10 seconds by default) as explained in https://docs.docker.com/reference/commandline/stop/