### PR TITLE
Support custom redis.conf files

### DIFF
--- a/commands
+++ b/commands
@@ -32,6 +32,7 @@ case "$1" in
     mkdir -p "$SERVICE_ROOT" || dokku_log_fail "Unable to create service directory"
     mkdir -p "$SERVICE_ROOT/data" || dokku_log_fail "Unable to create service data directory"
     mkdir -p "$SERVICE_ROOT/config" || dokku_log_fail "Unable to create service config directory"
+    curl http://download.redis.io/redis-stable/redis.conf > "$SERVICE_ROOT/config/redis.conf" || dokku_log_fail "Unable to download the default redis.conf to the config directory"
     touch "$LINKS_FILE"
 
     dokku_log_info1 "Starting container"
@@ -41,7 +42,7 @@ case "$1" in
       echo "" > "$SERVICE_ROOT/ENV"
     fi
     SERVICE_NAME=$(get_service_name "$SERVICE")
-    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/data" -v "$SERVICE_ROOT/config:/usr/local/etc/redis" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=redis "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
+    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/data" -v "$SERVICE_ROOT/config:/usr/local/etc/redis" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=redis "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" redis-server /usr/local/etc/redis/redis.conf)
     echo "$ID" > "$SERVICE_ROOT/ID"
 
     dokku_log_verbose_quiet "Waiting for container to be ready"

--- a/commands
+++ b/commands
@@ -32,7 +32,7 @@ case "$1" in
     mkdir -p "$SERVICE_ROOT" || dokku_log_fail "Unable to create service directory"
     mkdir -p "$SERVICE_ROOT/data" || dokku_log_fail "Unable to create service data directory"
     mkdir -p "$SERVICE_ROOT/config" || dokku_log_fail "Unable to create service config directory"
-    curl http://download.redis.io/redis-stable/redis.conf > "$SERVICE_ROOT/config/redis.conf" || dokku_log_fail "Unable to download the default redis.conf to the config directory"
+    curl "https://raw.githubusercontent.com/antirez/redis/${REDIS_IMAGE_VERSION:0:3}/redis.conf" > "$SERVICE_ROOT/config/redis.conf" || dokku_log_fail "Unable to download the default redis.conf to the config directory"
     touch "$LINKS_FILE"
 
     dokku_log_info1 "Starting container"


### PR DESCRIPTION
Even though the `$SERVICE_ROOT/config` volume is mapped to the `/usr/local/etc/redis` folder in the container, any specified `redis.conf` file in `$SERVICE_ROOT/config` will not be used by the running `redis-server` process. This pull request solves that problem, by downloading the `redis-stable/redis.conf` file from the redis website to `$SERVICE_ROOT/config/redis.conf`, then runs the redis server process in the container as `redis-server /usr/local/etc/redis/redis.conf`.

Users of `dokku-redis` will be able to configure the `$SERVICE_ROOT/config/redis.conf` file to their liking, restart the redis container and then see their changed configuration in effect.

This references [this issue](https://github.com/dokku/dokku-redis/issues/30).