### PR TITLE
Support locally-installed redis.conf

### DIFF
--- a/functions
+++ b/functions
@@ -39,7 +39,7 @@ service_create() {
   if [[ -z $REDIS_CONFIG_PATH ]] ; then
     curl -sSL "https://raw.githubusercontent.com/antirez/redis/${PLUGIN_IMAGE_VERSION:0:3}/redis.conf" > "$SERVICE_ROOT/config/redis.conf" || dokku_log_fail "Unable to download the default redis.conf to the config directory"
   else
-    cp "$REDIS_CONFIG_PATH" "$SERVICE_ROOT/config/redis.conf"
+    cp "$REDIS_CONFIG_PATH" "$SERVICE_ROOT/config/redis.conf" || dokku_log_fail "Unable to copy the ${REDIS_CONFIG_PATH} to the config directory"
   fi
   PASSWORD=$(openssl rand -hex 32)
   if [[ -n "$SERVICE_PASSWORD" ]]; then

--- a/functions
+++ b/functions
@@ -36,7 +36,11 @@ service_create() {
   mkdir -p "$SERVICE_ROOT" || dokku_log_fail "Unable to create service directory"
   mkdir -p "$SERVICE_ROOT/data" || dokku_log_fail "Unable to create service data directory"
   mkdir -p "$SERVICE_ROOT/config" || dokku_log_fail "Unable to create service config directory"
-  curl -sSL "https://raw.githubusercontent.com/antirez/redis/${PLUGIN_IMAGE_VERSION:0:3}/redis.conf" > "$SERVICE_ROOT/config/redis.conf" || dokku_log_fail "Unable to download the default redis.conf to the config directory"
+  if [[ -z $REDIS_CONFIG_PATH ]] ; then
+    curl -sSL "https://raw.githubusercontent.com/antirez/redis/${PLUGIN_IMAGE_VERSION:0:3}/redis.conf" > "$SERVICE_ROOT/config/redis.conf" || dokku_log_fail "Unable to download the default redis.conf to the config directory"
+  else
+    cp "$REDIS_CONFIG_PATH" "$SERVICE_ROOT/config/redis.conf"
+  fi
   PASSWORD=$(openssl rand -hex 32)
   if [[ -n "$SERVICE_PASSWORD" ]]; then
     PASSWORD="$SERVICE_PASSWORD"


### PR DESCRIPTION
In our case we need this because we _can't_ reasonably run `curl` from the container that runs Dokku, but this should be useful to anyone who wants to override the default config for their entire `dokku-redis` installation.

@josegonzalez FYI