### PR TITLE
fix: remove dokkupaas/s3backup container after backup

### DIFF
--- a/common-functions
+++ b/common-functions
@@ -183,7 +183,7 @@ service_backup() {
   fi
 
   # shellcheck disable=SC2086
-  docker run $BACKUP_PARAMETERS dokkupaas/s3backup:0.8.0
+  docker run --rm $BACKUP_PARAMETERS dokkupaas/s3backup:0.8.0
 }
 
 service_backup_auth() {


### PR DESCRIPTION
Same PR in dokku-postgres repo: dokku/dokku-postgres#159.