### PR TITLE
Update docker commands to use DOCKER_BIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,8 +693,8 @@ Remove the scheduled backup from cron:
 dokku redis:backup-unschedule lollipop
 ```
 
-### Disabling `docker pull` calls
+### Disabling `docker image pull` calls
 
-If you wish to disable the `docker pull` calls that the plugin triggers, you may set the `REDIS_DISABLE_PULL` environment variable to `true`. Once disabled, you will need to pull the service image you wish to deploy as shown in the `stderr` output.
+If you wish to disable the `docker image pull` calls that the plugin triggers, you may set the `REDIS_DISABLE_PULL` environment variable to `true`. Once disabled, you will need to pull the service image you wish to deploy as shown in the `stderr` output.
 
-Please ensure the proper images are in place when `docker pull` is disabled.
+Please ensure the proper images are in place when `docker image pull` is disabled.

--- a/bin/generate
+++ b/bin/generate
@@ -223,11 +223,11 @@ def usage_docker_pull(service, variable, alias, image, scheme, ports, options, u
     service_prefix = service.upper()
     return "\n".join(
         [
-            "### Disabling `docker pull` calls",
+            "### Disabling `docker image pull` calls",
             "",
-            f"If you wish to disable the `docker pull` calls that the plugin triggers, you may set the `{service_prefix}_DISABLE_PULL` environment variable to `true`. Once disabled, you will need to pull the service image you wish to deploy as shown in the `stderr` output.",
+            f"If you wish to disable the `docker image pull` calls that the plugin triggers, you may set the `{service_prefix}_DISABLE_PULL` environment variable to `true`. Once disabled, you will need to pull the service image you wish to deploy as shown in the `stderr` output.",
             "",
-            "Please ensure the proper images are in place when `docker pull` is disabled.",
+            "Please ensure the proper images are in place when `docker image pull` is disabled.",
         ]
     )
 

--- a/common-functions
+++ b/common-functions
@@ -94,7 +94,7 @@ docker_ports_options() {
 get_container_ip() {
   declare desc="retrieve the ip address of a container"
   declare CONTAINER_ID="$1"
-  docker inspect --format '{{ .NetworkSettings.IPAddress }}' "$CONTAINER_ID" 2>/dev/null
+  docker container inspect --format '{{ .NetworkSettings.IPAddress }}' "$CONTAINER_ID" 2>/dev/null
 }
 
 get_database_name() {
@@ -153,7 +153,7 @@ is_container_status() {
   declare desc="return 0 or 1 depending upon whether a given container has a certain status"
   declare CID="$1" STATUS="$2"
   local TEMPLATE="{{.State.$STATUS}}"
-  local CONTAINER_STATUS=$(docker inspect -f "$TEMPLATE" "$CID" 2>/dev/null || true)
+  local CONTAINER_STATUS=$(docker container inspect -f "$TEMPLATE" "$CID" 2>/dev/null || true)
 
   if [[ "$CONTAINER_STATUS" == "true" ]]; then
     return 0
@@ -208,7 +208,7 @@ retry-docker-command() {
   local i=0 success=false
   until [ $i -ge 100 ]; do
     set +e
-    suppress_output docker exec "$ID" sh -c "$COMMAND"
+    suppress_output docker container exec "$ID" sh -c "$COMMAND"
     exit_code=$?
     set -e
     if [[ "$exit_code" == 0 ]]; then
@@ -281,7 +281,7 @@ service_backup() {
   BACKUP_TMPDIR=$(mktemp -d --tmpdir)
   trap 'rm -rf "$BACKUP_TMPDIR" > /dev/null' RETURN INT TERM EXIT
 
-  docker inspect "$ID" &>/dev/null || dokku_log_fail "Service container does not exist"
+  docker container inspect "$ID" &>/dev/null || dokku_log_fail "Service container does not exist"
   is_container_status "$ID" "Running" || dokku_log_fail "Service container is not running"
 
   (service_export "$SERVICE" >"${BACKUP_TMPDIR}/export")
@@ -308,7 +308,7 @@ service_backup() {
   fi
 
   # shellcheck disable=SC2086
-  docker run --rm $BACKUP_PARAMETERS "$PLUGIN_S3BACKUP_IMAGE"
+  docker container run --rm $BACKUP_PARAMETERS "$PLUGIN_S3BACKUP_IMAGE"
 }
 
 service_commit_config() {
@@ -444,15 +444,15 @@ service_container_rm() {
   local ID
 
   service_pause "$SERVICE"
-  ID=$(docker ps -aq --no-trunc --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
+  ID=$(docker container ps -aq --no-trunc --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
   # this may be 'true' in tests...
   if [[ -z "$ID" ]] || [[ "$ID" == "true" ]]; then
     return 0
   fi
 
   dokku_log_verbose_quiet "Removing container"
-  docker update --restart=no "$SERVICE_NAME" >/dev/null 2>&1
-  if ! docker rm "$SERVICE_NAME" >/dev/null 2>&1; then
+  docker container update --restart=no "$SERVICE_NAME" >/dev/null 2>&1
+  if ! docker container rm "$SERVICE_NAME" >/dev/null 2>&1; then
     dokku_log_fail "Unable to remove container for service $SERVICE"
   fi
 }
@@ -470,13 +470,13 @@ service_enter() {
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local ID="$(cat "$SERVICE_ROOT/ID")"
 
-  docker inspect "$ID" &>/dev/null || dokku_log_fail "Service container does not exist"
+  docker container inspect "$ID" &>/dev/null || dokku_log_fail "Service container does not exist"
   is_container_status "$ID" "Running" || dokku_log_fail "Service container is not running"
 
   local EXEC_CMD=""
   has_tty && local DOKKU_RUN_OPTS+=" -i -t"
   # shellcheck disable=SC2086
-  docker exec $DOKKU_RUN_OPTS $ID $EXEC_CMD "${@:-/bin/bash}"
+  docker container exec $DOKKU_RUN_OPTS $ID $EXEC_CMD "${@:-/bin/bash}"
 }
 
 service_exists() {
@@ -509,7 +509,7 @@ service_image_exists() {
   [[ -f "$SERVICE_ROOT/IMAGE_VERSION" ]] && plugin_image_version="$(cat "$SERVICE_ROOT/IMAGE_VERSION")"
   local IMAGE="$plugin_image:$plugin_image_version"
 
-  if [[ "$(docker images -q "$IMAGE" 2>/dev/null)" == "" ]]; then
+  if [[ "$(docker image ls -q "$IMAGE" 2>/dev/null)" == "" ]]; then
     return 1
   fi
 
@@ -668,11 +668,11 @@ service_logs() {
     DOKKU_LOGS_ARGS+=" --follow"
   fi
 
-  docker inspect "$ID" &>/dev/null || dokku_log_fail "Service container does not exist"
+  docker container inspect "$ID" &>/dev/null || dokku_log_fail "Service container does not exist"
   is_container_status "$ID" "Running" || dokku_log_warn "Service logs may not be output as service is not running"
 
   # shellcheck disable=SC2086
-  docker logs $DOKKU_LOGS_ARGS "$ID" 2>&1
+  docker container logs $DOKKU_LOGS_ARGS "$ID" 2>&1
 }
 
 service_parse_args() {
@@ -790,7 +790,7 @@ service_port_pause() {
   fi
 
   local GREP_NAME="^/${EXPOSED_NAME}$"
-  local CONTAINER_NAME="$(docker ps -f name="$GREP_NAME" --format "{{.Names}}")"
+  local CONTAINER_NAME="$(docker container ps -f name="$GREP_NAME" --format "{{.Names}}")"
   if [[ -z "$CONTAINER_NAME" ]]; then
     if [[ "$LOG_FAIL" == "true" ]]; then
       dokku_log_info1 "Service $SERVICE unexposed"
@@ -799,8 +799,8 @@ service_port_pause() {
     return
   fi
 
-  docker stop "$EXPOSED_NAME" >/dev/null 2>&1 || true
-  docker rm "$EXPOSED_NAME" >/dev/null 2>&1 || true
+  docker container stop "$EXPOSED_NAME" >/dev/null 2>&1 || true
+  docker container rm "$EXPOSED_NAME" >/dev/null 2>&1 || true
   if [[ "$LOG_FAIL" == "true" ]]; then
     dokku_log_info1 "Service $SERVICE unexposed"
   fi
@@ -840,7 +840,7 @@ service_port_unpause() {
   echo "${PORTS[@]}" >"$PORT_FILE"
 
   # shellcheck disable=SC2046
-  docker run -d --link "$SERVICE_NAME:$PLUGIN_COMMAND_PREFIX" --name "$EXPOSED_NAME" $(docker_ports_options "${PORTS[@]}") --restart always --label dokku=ambassador --label "dokku.ambassador=$PLUGIN_COMMAND_PREFIX" "$PLUGIN_AMBASSADOR_IMAGE" >/dev/null
+  docker container run -d --link "$SERVICE_NAME:$PLUGIN_COMMAND_PREFIX" --name "$EXPOSED_NAME" $(docker_ports_options "${PORTS[@]}") --restart always --label dokku=ambassador --label "dokku.ambassador=$PLUGIN_COMMAND_PREFIX" "$PLUGIN_AMBASSADOR_IMAGE" >/dev/null
   if [[ "$LOG_FAIL" == "true" ]]; then
     dokku_log_info1 "Service $SERVICE exposed on port(s) [container->host]: $(service_exposed_ports "$SERVICE")"
   fi
@@ -891,7 +891,7 @@ service_status() {
   local ID="$(cat "$SERVICE_ROOT/ID")"
   local CONTAINER_STATUS
 
-  CONTAINER_STATUS=$(docker inspect -f "{{.State.Status}}" "$ID" 2>/dev/null || true)
+  CONTAINER_STATUS=$(docker container inspect -f "{{.State.Status}}" "$ID" 2>/dev/null || true)
   [[ -n "$CONTAINER_STATUS" ]] && echo "$CONTAINER_STATUS" && return 0
   echo "missing" && return 0
 }
@@ -901,12 +901,12 @@ service_pause() {
   declare SERVICE="$1"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
-  local ID=$(docker ps -aq --no-trunc --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
+  local ID=$(docker container ps -aq --no-trunc --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
   [[ -z $ID ]] && dokku_log_warn "Service is already paused" && return 0
 
   if [[ -n $ID ]]; then
     dokku_log_info2_quiet "Pausing container"
-    docker stop "$SERVICE_NAME" >/dev/null
+    docker container stop "$SERVICE_NAME" >/dev/null
     service_port_pause "$SERVICE"
     dokku_log_verbose_quiet "Container paused"
   else
@@ -949,7 +949,7 @@ service_version() {
   declare desc="display the running version for an image"
   declare SERVICE="$1"
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
-  docker inspect -f '{{.Config.Image}}' "$SERVICE_NAME" 2>/dev/null || true
+  docker container inspect -f '{{.Config.Image}}' "$SERVICE_NAME" 2>/dev/null || true
 }
 
 update_plugin_scheme_for_app() {

--- a/common-functions
+++ b/common-functions
@@ -94,7 +94,7 @@ docker_ports_options() {
 get_container_ip() {
   declare desc="retrieve the ip address of a container"
   declare CONTAINER_ID="$1"
-  docker container inspect --format '{{ .NetworkSettings.IPAddress }}' "$CONTAINER_ID" 2>/dev/null
+  "$DOCKER_BIN" container inspect --format '{{ .NetworkSettings.IPAddress }}' "$CONTAINER_ID" 2>/dev/null
 }
 
 get_database_name() {
@@ -153,7 +153,7 @@ is_container_status() {
   declare desc="return 0 or 1 depending upon whether a given container has a certain status"
   declare CID="$1" STATUS="$2"
   local TEMPLATE="{{.State.$STATUS}}"
-  local CONTAINER_STATUS=$(docker container inspect -f "$TEMPLATE" "$CID" 2>/dev/null || true)
+  local CONTAINER_STATUS=$("$DOCKER_BIN" container inspect -f "$TEMPLATE" "$CID" 2>/dev/null || true)
 
   if [[ "$CONTAINER_STATUS" == "true" ]]; then
     return 0
@@ -208,7 +208,7 @@ retry-docker-command() {
   local i=0 success=false
   until [ $i -ge 100 ]; do
     set +e
-    suppress_output docker container exec "$ID" sh -c "$COMMAND"
+    suppress_output "$DOCKER_BIN" container exec "$ID" sh -c "$COMMAND"
     exit_code=$?
     set -e
     if [[ "$exit_code" == 0 ]]; then
@@ -281,7 +281,7 @@ service_backup() {
   BACKUP_TMPDIR=$(mktemp -d --tmpdir)
   trap 'rm -rf "$BACKUP_TMPDIR" > /dev/null' RETURN INT TERM EXIT
 
-  docker container inspect "$ID" &>/dev/null || dokku_log_fail "Service container does not exist"
+  "$DOCKER_BIN" container inspect "$ID" &>/dev/null || dokku_log_fail "Service container does not exist"
   is_container_status "$ID" "Running" || dokku_log_fail "Service container is not running"
 
   (service_export "$SERVICE" >"${BACKUP_TMPDIR}/export")
@@ -308,7 +308,7 @@ service_backup() {
   fi
 
   # shellcheck disable=SC2086
-  docker container run --rm $BACKUP_PARAMETERS "$PLUGIN_S3BACKUP_IMAGE"
+  "$DOCKER_BIN" container run --rm $BACKUP_PARAMETERS "$PLUGIN_S3BACKUP_IMAGE"
 }
 
 service_commit_config() {
@@ -444,15 +444,15 @@ service_container_rm() {
   local ID
 
   service_pause "$SERVICE"
-  ID=$(docker container ps -aq --no-trunc --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
+  ID=$("$DOCKER_BIN" container ps -aq --no-trunc --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
   # this may be 'true' in tests...
   if [[ -z "$ID" ]] || [[ "$ID" == "true" ]]; then
     return 0
   fi
 
   dokku_log_verbose_quiet "Removing container"
-  docker container update --restart=no "$SERVICE_NAME" >/dev/null 2>&1
-  if ! docker container rm "$SERVICE_NAME" >/dev/null 2>&1; then
+  "$DOCKER_BIN" container update --restart=no "$SERVICE_NAME" >/dev/null 2>&1
+  if ! "$DOCKER_BIN" container rm "$SERVICE_NAME" >/dev/null 2>&1; then
     dokku_log_fail "Unable to remove container for service $SERVICE"
   fi
 }
@@ -470,13 +470,13 @@ service_enter() {
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local ID="$(cat "$SERVICE_ROOT/ID")"
 
-  docker container inspect "$ID" &>/dev/null || dokku_log_fail "Service container does not exist"
+  "$DOCKER_BIN" container inspect "$ID" &>/dev/null || dokku_log_fail "Service container does not exist"
   is_container_status "$ID" "Running" || dokku_log_fail "Service container is not running"
 
   local EXEC_CMD=""
   has_tty && local DOKKU_RUN_OPTS+=" -i -t"
   # shellcheck disable=SC2086
-  docker container exec $DOKKU_RUN_OPTS $ID $EXEC_CMD "${@:-/bin/bash}"
+  "$DOCKER_BIN" container exec $DOKKU_RUN_OPTS $ID $EXEC_CMD "${@:-/bin/bash}"
 }
 
 service_exists() {
@@ -509,7 +509,7 @@ service_image_exists() {
   [[ -f "$SERVICE_ROOT/IMAGE_VERSION" ]] && plugin_image_version="$(cat "$SERVICE_ROOT/IMAGE_VERSION")"
   local IMAGE="$plugin_image:$plugin_image_version"
 
-  if [[ "$(docker image ls -q "$IMAGE" 2>/dev/null)" == "" ]]; then
+  if [[ "$("$DOCKER_BIN" image ls -q "$IMAGE" 2>/dev/null)" == "" ]]; then
     return 1
   fi
 
@@ -668,11 +668,11 @@ service_logs() {
     DOKKU_LOGS_ARGS+=" --follow"
   fi
 
-  docker container inspect "$ID" &>/dev/null || dokku_log_fail "Service container does not exist"
+  "$DOCKER_BIN" container inspect "$ID" &>/dev/null || dokku_log_fail "Service container does not exist"
   is_container_status "$ID" "Running" || dokku_log_warn "Service logs may not be output as service is not running"
 
   # shellcheck disable=SC2086
-  docker container logs $DOKKU_LOGS_ARGS "$ID" 2>&1
+  "$DOCKER_BIN" container logs $DOKKU_LOGS_ARGS "$ID" 2>&1
 }
 
 service_parse_args() {
@@ -790,7 +790,7 @@ service_port_pause() {
   fi
 
   local GREP_NAME="^/${EXPOSED_NAME}$"
-  local CONTAINER_NAME="$(docker container ps -f name="$GREP_NAME" --format "{{.Names}}")"
+  local CONTAINER_NAME="$("$DOCKER_BIN" container ps -f name="$GREP_NAME" --format "{{.Names}}")"
   if [[ -z "$CONTAINER_NAME" ]]; then
     if [[ "$LOG_FAIL" == "true" ]]; then
       dokku_log_info1 "Service $SERVICE unexposed"
@@ -799,8 +799,8 @@ service_port_pause() {
     return
   fi
 
-  docker container stop "$EXPOSED_NAME" >/dev/null 2>&1 || true
-  docker container rm "$EXPOSED_NAME" >/dev/null 2>&1 || true
+  "$DOCKER_BIN" container stop "$EXPOSED_NAME" >/dev/null 2>&1 || true
+  "$DOCKER_BIN" container rm "$EXPOSED_NAME" >/dev/null 2>&1 || true
   if [[ "$LOG_FAIL" == "true" ]]; then
     dokku_log_info1 "Service $SERVICE unexposed"
   fi
@@ -840,7 +840,7 @@ service_port_unpause() {
   echo "${PORTS[@]}" >"$PORT_FILE"
 
   # shellcheck disable=SC2046
-  docker container run -d --link "$SERVICE_NAME:$PLUGIN_COMMAND_PREFIX" --name "$EXPOSED_NAME" $(docker_ports_options "${PORTS[@]}") --restart always --label dokku=ambassador --label "dokku.ambassador=$PLUGIN_COMMAND_PREFIX" "$PLUGIN_AMBASSADOR_IMAGE" >/dev/null
+  "$DOCKER_BIN" container run -d --link "$SERVICE_NAME:$PLUGIN_COMMAND_PREFIX" --name "$EXPOSED_NAME" $(docker_ports_options "${PORTS[@]}") --restart always --label dokku=ambassador --label "dokku.ambassador=$PLUGIN_COMMAND_PREFIX" "$PLUGIN_AMBASSADOR_IMAGE" >/dev/null
   if [[ "$LOG_FAIL" == "true" ]]; then
     dokku_log_info1 "Service $SERVICE exposed on port(s) [container->host]: $(service_exposed_ports "$SERVICE")"
   fi
@@ -891,7 +891,7 @@ service_status() {
   local ID="$(cat "$SERVICE_ROOT/ID")"
   local CONTAINER_STATUS
 
-  CONTAINER_STATUS=$(docker container inspect -f "{{.State.Status}}" "$ID" 2>/dev/null || true)
+  CONTAINER_STATUS=$("$DOCKER_BIN" container inspect -f "{{.State.Status}}" "$ID" 2>/dev/null || true)
   [[ -n "$CONTAINER_STATUS" ]] && echo "$CONTAINER_STATUS" && return 0
   echo "missing" && return 0
 }
@@ -901,12 +901,12 @@ service_pause() {
   declare SERVICE="$1"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
-  local ID=$(docker container ps -aq --no-trunc --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
+  local ID=$("$DOCKER_BIN" container ps -aq --no-trunc --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
   [[ -z $ID ]] && dokku_log_warn "Service is already paused" && return 0
 
   if [[ -n $ID ]]; then
     dokku_log_info2_quiet "Pausing container"
-    docker container stop "$SERVICE_NAME" >/dev/null
+    "$DOCKER_BIN" container stop "$SERVICE_NAME" >/dev/null
     service_port_pause "$SERVICE"
     dokku_log_verbose_quiet "Container paused"
   else
@@ -949,7 +949,7 @@ service_version() {
   declare desc="display the running version for an image"
   declare SERVICE="$1"
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
-  docker container inspect -f '{{.Config.Image}}' "$SERVICE_NAME" 2>/dev/null || true
+  "$DOCKER_BIN" container inspect -f '{{.Config.Image}}' "$SERVICE_NAME" 2>/dev/null || true
 }
 
 update_plugin_scheme_for_app() {

--- a/functions
+++ b/functions
@@ -17,7 +17,7 @@ service_connect() {
   local SERVICE_TTY_OPTS
   has_tty && SERVICE_TTY_OPTS="-t"
 
-  docker exec --env=LANG=C.UTF-8 --env=LC_ALL=C.UTF-8 -i $SERVICE_TTY_OPTS "$SERVICE_NAME" redis-cli -a "$PASSWORD"
+  docker container exec --env=LANG=C.UTF-8 --env=LC_ALL=C.UTF-8 -i $SERVICE_TTY_OPTS "$SERVICE_NAME" redis-cli -a "$PASSWORD"
 }
 
 service_create() {
@@ -33,11 +33,11 @@ service_create() {
   if ! service_image_exists "$SERVICE"; then
     if [[ "$PLUGIN_DISABLE_PULL" == "true" ]]; then
       dokku_log_warn "${PLUGIN_DISABLE_PULL_VARIABLE} environment variable detected. Not running pull command." 1>&2
-      dokku_log_warn "   docker pull ${IMAGE}" 1>&2
+      dokku_log_warn "   docker image pull ${IMAGE}" 1>&2
       dokku_log_warn "$PLUGIN_SERVICE service creation failed"
       exit 1
     fi
-    docker pull "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" || dokku_log_fail "$PLUGIN_SERVICE image $PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION pull failed"
+    docker image pull "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" || dokku_log_fail "$PLUGIN_SERVICE image $PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION pull failed"
   fi
 
   plugn trigger service-action pre-create "$PLUGIN_COMMAND_PREFIX" "$SERVICE"
@@ -91,11 +91,11 @@ service_create_container() {
   [[ -f "$SERVICE_ROOT/IMAGE_VERSION" ]] && PLUGIN_IMAGE_VERSION="$(cat "$SERVICE_ROOT/IMAGE_VERSION")"
 
   # shellcheck disable=SC2086
-  ID=$(docker run --name "$SERVICE_NAME" $MEMORY_LIMIT $SHM_SIZE -v "$SERVICE_HOST_ROOT/data:/data" -v "$SERVICE_HOST_ROOT/$PLUGIN_CONFIG_SUFFIX:/usr/local/etc/redis" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=redis "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" redis-server /usr/local/etc/redis/redis.conf --bind 0.0.0.0 $CONFIG_OPTIONS)
+  ID=$(docker container run --name "$SERVICE_NAME" $MEMORY_LIMIT $SHM_SIZE -v "$SERVICE_HOST_ROOT/data:/data" -v "$SERVICE_HOST_ROOT/$PLUGIN_CONFIG_SUFFIX:/usr/local/etc/redis" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=redis "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" redis-server /usr/local/etc/redis/redis.conf --bind 0.0.0.0 $CONFIG_OPTIONS)
   echo "$ID" >"$SERVICE_ROOT/ID"
 
   dokku_log_verbose_quiet "Waiting for container to be ready"
-  docker run --rm --link "$SERVICE_NAME:$PLUGIN_COMMAND_PREFIX" "$PLUGIN_WAIT_IMAGE" -p "$PLUGIN_DATASTORE_WAIT_PORT" >/dev/null
+  docker container run --rm --link "$SERVICE_NAME:$PLUGIN_COMMAND_PREFIX" "$PLUGIN_WAIT_IMAGE" -p "$PLUGIN_DATASTORE_WAIT_PORT" >/dev/null
 
   dokku_log_info2 "$PLUGIN_SERVICE container created: $SERVICE"
   service_info "$SERVICE"
@@ -108,16 +108,16 @@ service_export() {
   local PASSWORD="$(service_password "$SERVICE")"
 
   [[ -n $SSH_TTY ]] && stty -opost
-  LASTSAVE1=$(docker exec "$SERVICE_NAME" bash -c "echo LASTSAVE | redis-cli -a ${PASSWORD}")
-  docker exec "$SERVICE_NAME" bash -c "echo BGSAVE | redis-cli -a ${PASSWORD}" >/dev/null 2>&1
-  LASTSAVE2=$(docker exec "$SERVICE_NAME" bash -c "echo LASTSAVE | redis-cli -a ${PASSWORD}")
+  LASTSAVE1=$(docker container exec "$SERVICE_NAME" bash -c "echo LASTSAVE | redis-cli -a ${PASSWORD}")
+  docker container exec "$SERVICE_NAME" bash -c "echo BGSAVE | redis-cli -a ${PASSWORD}" >/dev/null 2>&1
+  LASTSAVE2=$(docker container exec "$SERVICE_NAME" bash -c "echo LASTSAVE | redis-cli -a ${PASSWORD}")
 
   until [[ "$LASTSAVE1" != "$LASTSAVE2" ]]; do
-    LASTSAVE2=$(docker exec "$SERVICE_NAME" bash -c "echo LASTSAVE | redis-cli -a ${PASSWORD}")
+    LASTSAVE2=$(docker container exec "$SERVICE_NAME" bash -c "echo LASTSAVE | redis-cli -a ${PASSWORD}")
     sleep 5
   done
 
-  docker exec "$SERVICE_NAME" cat /data/dump.rdb
+  docker container exec "$SERVICE_NAME" cat /data/dump.rdb
   status=$?
   [[ -n $SSH_TTY ]] && stty opost
   exit $status
@@ -132,7 +132,7 @@ service_import() {
     dokku_log_fail "No data provided on stdin."
   fi
   dokku "$PLUGIN_COMMAND_PREFIX:stop" "$SERVICE" >/dev/null 2>&1
-  docker run --rm -i -v "$SERVICE_HOST_ROOT/data:/data" "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" bash -c "cat > /data/dump.rdb && chown redis: /data/dump.rdb"
+  docker container run --rm -i -v "$SERVICE_HOST_ROOT/data:/data" "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" bash -c "cat > /data/dump.rdb && chown redis: /data/dump.rdb"
   dokku "$PLUGIN_COMMAND_PREFIX:start" "$SERVICE" >/dev/null 2>&1
 }
 
@@ -141,7 +141,7 @@ service_start() {
   local QUIET="$2"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
-  local ID=$(docker ps -aq --no-trunc --filter "status=running" --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
+  local ID=$(docker container ps -aq --no-trunc --filter "status=running" --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
   if [[ -n $ID ]]; then
     [[ -z $QUIET ]] && dokku_log_warn "Service is already started"
     if [[ ! -f "$SERVICE_ROOT/ID" ]] || [[ "$(cat "$SERVICE_ROOT/ID")" != "$ID" ]]; then
@@ -152,10 +152,10 @@ service_start() {
   fi
 
   dokku_log_info2_quiet "Starting container"
-  local PREVIOUS_ID=$(docker ps -aq --no-trunc --filter "status=exited" --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
+  local PREVIOUS_ID=$(docker container ps -aq --no-trunc --filter "status=exited" --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
 
   if [[ -n $PREVIOUS_ID ]]; then
-    docker start "$PREVIOUS_ID" >/dev/null
+    docker container start "$PREVIOUS_ID" >/dev/null
     service_port_unpause "$SERVICE"
     dokku_log_info2 "Container started"
   elif service_image_exists "$SERVICE"; then

--- a/functions
+++ b/functions
@@ -17,7 +17,7 @@ service_connect() {
   local SERVICE_TTY_OPTS
   has_tty && SERVICE_TTY_OPTS="-t"
 
-  docker container exec --env=LANG=C.UTF-8 --env=LC_ALL=C.UTF-8 -i $SERVICE_TTY_OPTS "$SERVICE_NAME" redis-cli -a "$PASSWORD"
+  "$DOCKER_BIN" container exec --env=LANG=C.UTF-8 --env=LC_ALL=C.UTF-8 -i $SERVICE_TTY_OPTS "$SERVICE_NAME" redis-cli -a "$PASSWORD"
 }
 
 service_create() {
@@ -37,7 +37,7 @@ service_create() {
       dokku_log_warn "$PLUGIN_SERVICE service creation failed"
       exit 1
     fi
-    docker image pull "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" || dokku_log_fail "$PLUGIN_SERVICE image $PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION pull failed"
+    "$DOCKER_BIN" image pull "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" || dokku_log_fail "$PLUGIN_SERVICE image $PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION pull failed"
   fi
 
   plugn trigger service-action pre-create "$PLUGIN_COMMAND_PREFIX" "$SERVICE"
@@ -91,11 +91,11 @@ service_create_container() {
   [[ -f "$SERVICE_ROOT/IMAGE_VERSION" ]] && PLUGIN_IMAGE_VERSION="$(cat "$SERVICE_ROOT/IMAGE_VERSION")"
 
   # shellcheck disable=SC2086
-  ID=$(docker container run --name "$SERVICE_NAME" $MEMORY_LIMIT $SHM_SIZE -v "$SERVICE_HOST_ROOT/data:/data" -v "$SERVICE_HOST_ROOT/$PLUGIN_CONFIG_SUFFIX:/usr/local/etc/redis" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=redis "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" redis-server /usr/local/etc/redis/redis.conf --bind 0.0.0.0 $CONFIG_OPTIONS)
+  ID=$("$DOCKER_BIN" container run --name "$SERVICE_NAME" $MEMORY_LIMIT $SHM_SIZE -v "$SERVICE_HOST_ROOT/data:/data" -v "$SERVICE_HOST_ROOT/$PLUGIN_CONFIG_SUFFIX:/usr/local/etc/redis" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=redis "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" redis-server /usr/local/etc/redis/redis.conf --bind 0.0.0.0 $CONFIG_OPTIONS)
   echo "$ID" >"$SERVICE_ROOT/ID"
 
   dokku_log_verbose_quiet "Waiting for container to be ready"
-  docker container run --rm --link "$SERVICE_NAME:$PLUGIN_COMMAND_PREFIX" "$PLUGIN_WAIT_IMAGE" -p "$PLUGIN_DATASTORE_WAIT_PORT" >/dev/null
+  "$DOCKER_BIN" container run --rm --link "$SERVICE_NAME:$PLUGIN_COMMAND_PREFIX" "$PLUGIN_WAIT_IMAGE" -p "$PLUGIN_DATASTORE_WAIT_PORT" >/dev/null
 
   dokku_log_info2 "$PLUGIN_SERVICE container created: $SERVICE"
   service_info "$SERVICE"
@@ -108,16 +108,16 @@ service_export() {
   local PASSWORD="$(service_password "$SERVICE")"
 
   [[ -n $SSH_TTY ]] && stty -opost
-  LASTSAVE1=$(docker container exec "$SERVICE_NAME" bash -c "echo LASTSAVE | redis-cli -a ${PASSWORD}")
-  docker container exec "$SERVICE_NAME" bash -c "echo BGSAVE | redis-cli -a ${PASSWORD}" >/dev/null 2>&1
-  LASTSAVE2=$(docker container exec "$SERVICE_NAME" bash -c "echo LASTSAVE | redis-cli -a ${PASSWORD}")
+  LASTSAVE1=$("$DOCKER_BIN" container exec "$SERVICE_NAME" bash -c "echo LASTSAVE | redis-cli -a ${PASSWORD}")
+  "$DOCKER_BIN" container exec "$SERVICE_NAME" bash -c "echo BGSAVE | redis-cli -a ${PASSWORD}" >/dev/null 2>&1
+  LASTSAVE2=$("$DOCKER_BIN" container exec "$SERVICE_NAME" bash -c "echo LASTSAVE | redis-cli -a ${PASSWORD}")
 
   until [[ "$LASTSAVE1" != "$LASTSAVE2" ]]; do
-    LASTSAVE2=$(docker container exec "$SERVICE_NAME" bash -c "echo LASTSAVE | redis-cli -a ${PASSWORD}")
+    LASTSAVE2=$("$DOCKER_BIN" container exec "$SERVICE_NAME" bash -c "echo LASTSAVE | redis-cli -a ${PASSWORD}")
     sleep 5
   done
 
-  docker container exec "$SERVICE_NAME" cat /data/dump.rdb
+  "$DOCKER_BIN" container exec "$SERVICE_NAME" cat /data/dump.rdb
   status=$?
   [[ -n $SSH_TTY ]] && stty opost
   exit $status
@@ -132,7 +132,7 @@ service_import() {
     dokku_log_fail "No data provided on stdin."
   fi
   dokku "$PLUGIN_COMMAND_PREFIX:stop" "$SERVICE" >/dev/null 2>&1
-  docker container run --rm -i -v "$SERVICE_HOST_ROOT/data:/data" "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" bash -c "cat > /data/dump.rdb && chown redis: /data/dump.rdb"
+  "$DOCKER_BIN" container run --rm -i -v "$SERVICE_HOST_ROOT/data:/data" "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" bash -c "cat > /data/dump.rdb && chown redis: /data/dump.rdb"
   dokku "$PLUGIN_COMMAND_PREFIX:start" "$SERVICE" >/dev/null 2>&1
 }
 
@@ -141,7 +141,7 @@ service_start() {
   local QUIET="$2"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
-  local ID=$(docker container ps -aq --no-trunc --filter "status=running" --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
+  local ID=$("$DOCKER_BIN" container ps -aq --no-trunc --filter "status=running" --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
   if [[ -n $ID ]]; then
     [[ -z $QUIET ]] && dokku_log_warn "Service is already started"
     if [[ ! -f "$SERVICE_ROOT/ID" ]] || [[ "$(cat "$SERVICE_ROOT/ID")" != "$ID" ]]; then
@@ -152,10 +152,10 @@ service_start() {
   fi
 
   dokku_log_info2_quiet "Starting container"
-  local PREVIOUS_ID=$(docker container ps -aq --no-trunc --filter "status=exited" --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
+  local PREVIOUS_ID=$("$DOCKER_BIN" container ps -aq --no-trunc --filter "status=exited" --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
 
   if [[ -n $PREVIOUS_ID ]]; then
-    docker container start "$PREVIOUS_ID" >/dev/null
+    "$DOCKER_BIN" container start "$PREVIOUS_ID" >/dev/null
     service_port_unpause "$SERVICE"
     dokku_log_info2 "Container started"
   elif service_image_exists "$SERVICE"; then

--- a/install
+++ b/install
@@ -12,8 +12,8 @@ plugin-install() {
       echo " !        docker image pull ${IMAGE}" 1>&2
       return
     fi
-    if [[ "$(docker image ls -q "${IMAGE}" 2>/dev/null)" == "" ]]; then
-      docker image pull "${IMAGE}"
+    if [[ "$("$DOCKER_BIN" image ls -q "${IMAGE}" 2>/dev/null)" == "" ]]; then
+      "$DOCKER_BIN" image pull "${IMAGE}"
     fi
   }
 

--- a/install
+++ b/install
@@ -9,11 +9,11 @@ plugin-install() {
     declare IMAGE="$1"
     if [[ "$PLUGIN_DISABLE_PULL" == "true" ]]; then
       echo " !     ${PLUGIN_DISABLE_PULL_VARIABLE} environment variable detected. Not running pull command." 1>&2
-      echo " !        docker pull ${IMAGE}" 1>&2
+      echo " !        docker image pull ${IMAGE}" 1>&2
       return
     fi
-    if [[ "$(docker images -q "${IMAGE}" 2>/dev/null)" == "" ]]; then
-      docker pull "${IMAGE}"
+    if [[ "$(docker image ls -q "${IMAGE}" 2>/dev/null)" == "" ]]; then
+      docker image pull "${IMAGE}"
     fi
   }
 

--- a/subcommands/destroy
+++ b/subcommands/destroy
@@ -46,7 +46,7 @@ service-destroy-cmd() {
   service_container_rm "$SERVICE"
 
   dokku_log_verbose_quiet "Removing data"
-  docker container run --rm -v "$SERVICE_HOST_ROOT/data:/data" -v "$SERVICE_HOST_ROOT/$PLUGIN_CONFIG_SUFFIX:/config" "$PLUGIN_BUSYBOX_IMAGE" chmod 777 -R /config /data
+  "$DOCKER_BIN" container run --rm -v "$SERVICE_HOST_ROOT/data:/data" -v "$SERVICE_HOST_ROOT/$PLUGIN_CONFIG_SUFFIX:/config" "$PLUGIN_BUSYBOX_IMAGE" chmod 777 -R /config /data
   rm -rf "$SERVICE_ROOT"
 
   plugn trigger service-action post-delete "$PLUGIN_COMMAND_PREFIX" "$SERVICE"

--- a/subcommands/destroy
+++ b/subcommands/destroy
@@ -46,7 +46,7 @@ service-destroy-cmd() {
   service_container_rm "$SERVICE"
 
   dokku_log_verbose_quiet "Removing data"
-  docker run --rm -v "$SERVICE_HOST_ROOT/data:/data" -v "$SERVICE_HOST_ROOT/$PLUGIN_CONFIG_SUFFIX:/config" "$PLUGIN_BUSYBOX_IMAGE" chmod 777 -R /config /data
+  docker container run --rm -v "$SERVICE_HOST_ROOT/data:/data" -v "$SERVICE_HOST_ROOT/$PLUGIN_CONFIG_SUFFIX:/config" "$PLUGIN_BUSYBOX_IMAGE" chmod 777 -R /config /data
   rm -rf "$SERVICE_ROOT"
 
   plugn trigger service-action post-delete "$PLUGIN_COMMAND_PREFIX" "$SERVICE"

--- a/subcommands/upgrade
+++ b/subcommands/upgrade
@@ -45,7 +45,7 @@ service-upgrade-cmd() {
       dokku_log_warn "$PLUGIN_SERVICE service $SERVICE upgrade failed"
       exit 1
     fi
-    docker image pull "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" || dokku_log_fail "$PLUGIN_SERVICE image $PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION pull failed"
+    "$DOCKER_BIN" image pull "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" || dokku_log_fail "$PLUGIN_SERVICE image $PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION pull failed"
   fi
 
   service_commit_config "$SERVICE"

--- a/subcommands/upgrade
+++ b/subcommands/upgrade
@@ -41,11 +41,11 @@ service-upgrade-cmd() {
   if ! service_image_exists "$SERVICE"; then
     if [[ "$PLUGIN_DISABLE_PULL" == "true" ]]; then
       dokku_log_warn "${PLUGIN_DISABLE_PULL_VARIABLE} environment variable detected. Not running pull command." 1>&2
-      dokku_log_warn "   docker pull ${IMAGE}" 1>&2
+      dokku_log_warn "   docker image pull ${IMAGE}" 1>&2
       dokku_log_warn "$PLUGIN_SERVICE service $SERVICE upgrade failed"
       exit 1
     fi
-    docker pull "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" || dokku_log_fail "$PLUGIN_SERVICE image $PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION pull failed"
+    docker image pull "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" || dokku_log_fail "$PLUGIN_SERVICE image $PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION pull failed"
   fi
 
   service_commit_config "$SERVICE"


### PR DESCRIPTION
This updates all docker commands to use the `DOCKER_BIN` environment variable, allowing us to switch the underlying container implementation from docker to podman.

Note that some commands - such as `docker container update` - may still fail, so this doesn't completely give podman support, but at least brings us mostly there.