### PR TITLE
fix: read version information from image

### DIFF
--- a/functions
+++ b/functions
@@ -48,7 +48,7 @@ service_create() {
   touch "$LINKS_FILE"
 
   if [[ -z $REDIS_CONFIG_PATH ]]; then
-    VERSION=$("$DOCKER_BIN"  run --rm --entrypoint redis-server "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" --version | grep -o 'v=\d*\.\d*\.\d*')
+    VERSION=$("$DOCKER_BIN" run --rm --entrypoint redis-server "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" --version | grep -oP 'v=\d+\.\d+\.\d+')
     if [[ -z "$VERSION" ]]; then
       dokku_log_fail "Could not get version information from $PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION image"
     fi

--- a/functions
+++ b/functions
@@ -48,7 +48,11 @@ service_create() {
   touch "$LINKS_FILE"
 
   if [[ -z $REDIS_CONFIG_PATH ]]; then
-    curl -sSL "https://raw.githubusercontent.com/antirez/redis/${PLUGIN_IMAGE_VERSION:0:3}/redis.conf" >"$SERVICE_ROOT/$PLUGIN_CONFIG_SUFFIX/redis.conf" || dokku_log_fail "Unable to download the default redis.conf to the config directory"
+    VERSION=$("$DOCKER_BIN"  run --rm --entrypoint redis-server "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" --version | grep -o 'v=\d*\.\d*\.\d*')
+    if [[ -z "$VERSION" ]]; then
+      dokku_log_fail "Could not get version information from $PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION image"
+    fi
+    curl -sSL "https://raw.githubusercontent.com/antirez/redis/${VERSION:2}/redis.conf" >"$SERVICE_ROOT/$PLUGIN_CONFIG_SUFFIX/redis.conf" || dokku_log_fail "Unable to download the default redis.conf to the config directory"
   else
     cp "$REDIS_CONFIG_PATH" "$SERVICE_ROOT/$PLUGIN_CONFIG_SUFFIX/redis.conf" || dokku_log_fail "Unable to copy the ${REDIS_CONFIG_PATH} to the config directory"
   fi

--- a/tests/service_create.bats
+++ b/tests/service_create.bats
@@ -15,6 +15,26 @@ load test_helper
   dokku --force "$PLUGIN_COMMAND_PREFIX:destroy" service-with-dashes
 }
 
+@test "($PLUGIN_COMMAND_PREFIX:create) service with redisgears image" {
+  export PLUGIN_IMAGE="redislabs/redisgears"
+  export PLUGIN_IMAGE_VERSION="1.2.5"
+  run dokku "$PLUGIN_COMMAND_PREFIX:create" service-with-redisgears
+  assert_contains "${lines[*]}" "container created: service-with-redisgears"
+  assert_contains "${lines[*]}" "dokku-$PLUGIN_COMMAND_PREFIX-service-with-redisgears"
+
+  dokku --force "$PLUGIN_COMMAND_PREFIX:destroy" service-with-redisgears
+}
+
+@test "($PLUGIN_COMMAND_PREFIX:create) service with redis-stack image" {
+  export PLUGIN_IMAGE="redis/redis-stack"
+  export PLUGIN_IMAGE_VERSION="6.2.6-v9"
+  run dokku "$PLUGIN_COMMAND_PREFIX:create" service-with-redis-stack
+  assert_contains "${lines[*]}" "container created: service-with-redis-stack"
+  assert_contains "${lines[*]}" "dokku-$PLUGIN_COMMAND_PREFIX-service-with-redis-stack"
+
+  dokku --force "$PLUGIN_COMMAND_PREFIX:destroy" service-with-redis-stack
+}
+
 @test "($PLUGIN_COMMAND_PREFIX:create) error when there are no arguments" {
   run dokku "$PLUGIN_COMMAND_PREFIX:create"
   assert_contains "${lines[*]}" "Please specify a valid name for the service"


### PR DESCRIPTION
This is an attempt to fix #128 

Pro:
- Reading the version number from the image worked for me with `redis`, `redislabs/rejson`, and `redis/redis-stack` because they all use `redis-server` binary.
- No need for a new variable.

Contra:
- Unfortunately, this won't work with `eqalpha/keydb` and `docker.dragonflydb.io/dragonflydb/dragonfly`.