### PR TITLE
fix: use correct repository on arm64 ubuntu image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 HARDWARE = $(shell uname -m)
 SYSTEM_NAME  = $(shell uname -s | tr '[:upper:]' '[:lower:]')
+ARCH = $(shell dpkg --print-architecture)
 SHFMT_VERSION = 3.0.2
 XUNIT_TO_GITHUB_VERSION = 0.3.0
 XUNIT_READER_VERSION = 0.1.0
@@ -21,7 +22,11 @@ ifneq ($(shell shellcheck --version >/dev/null 2>&1 ; echo $$?),0)
 ifeq ($(SYSTEM_NAME),darwin)
 	brew install shellcheck
 else
+ifeq ($(ARCH),arm64)
+	sudo add-apt-repository 'deb http://ports.ubuntu.com/ubuntu-ports focal-backports main restricted universe multiverse'
+else
 	sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse'
+endif
 	sudo rm -rf /var/lib/apt/lists/* && sudo apt-get clean
 	sudo apt-get update -qq && sudo apt-get install -qq -y shellcheck
 endif


### PR DESCRIPTION
I had to make some changes to be able to use the Dev Container on an arm64 device which pulls arm64 Ubuntu image.

- `http://archive.ubuntu.com/ubuntu` contains releases for: amd64, i386
- `http://ports.ubuntu.com/ubuntu-ports` contains releases for: arm64, armhf, ppc64el, s390x

In this PR I only added a condition for arm64 but other architectures can included.